### PR TITLE
fix(ALM v0.2.0): STD-001 comment address range 1–247

### DIFF
--- a/ALM-173-R1/Firmware/v0.2.0/default_alm_173_r1/default_alm_173_r1.ino
+++ b/ALM-173-R1/Firmware/v0.2.0/default_alm_173_r1/default_alm_173_r1.ino
@@ -515,7 +515,7 @@ void disarmLocal();
 static bool readEnabledInput(int i);
 
 // ================== Handlers ==================
-// values: { "mb_address": <1..255>, "mb_baud": <9600..115200> }
+// values: { "mb_address": <1..247>, "mb_baud": <9600..115200> }
 void handleValues(JSONVar values) {
   int addr = (int)values["mb_address"];
   int baud = (int)values["mb_baud"];


### PR DESCRIPTION
## Summary
- Correct the `handleValues` comment from `1..255` to `1..247` (STD-001). Runtime already uses `hmValidAddress`.

## Test plan
- [ ] Comment-only; no binary change required.


Made with [Cursor](https://cursor.com)