### PR TITLE
fix(ENM-223-R1 v0.2.0 WebConfig): English CT HUD label (was Russian)

### DIFF
--- a/ENM-223-R1/Firmware/v0.2.0/ConfigToolPage.html
+++ b/ENM-223-R1/Firmware/v0.2.0/ConfigToolPage.html
@@ -165,7 +165,7 @@
       <div class="hint" style="margin-top:.4rem">
         N = primary / secondary_mA (software scale). PGA writes the chip — change only with the input path.
         <span id="ct-ratio-n">N = 2</span>
-        · <span id="ct-sec-util">вход = — % от 60 мА</span>
+        · <span id="ct-sec-util">input = — % of 60 mA</span>
         <span id="ct-overrange" style="display:none;color:#b00020;font-weight:600"> OVERRANGE</span>
       </div>
     </div>
@@ -389,8 +389,8 @@
       const pct = (maxSec_mA / 60) * 100;
       if (utilEl) {
         utilEl.textContent = Number.isFinite(pct)
-          ? ('вход = ' + pct.toFixed(0) + ' % от 60 мА')
-          : 'вход = — % от 60 мА';
+          ? ('input = ' + pct.toFixed(0) + ' % of 60 mA')
+          : 'input = — % of 60 mA';
         utilEl.style.color = pct > 90 ? '#b06000' : '';
       }
       if (ovEl) ovEl.style.display = (pct >= 100) ? 'inline' : 'none';


### PR DESCRIPTION
## Summary
- Replace Russian CT HUD strings (`вход = … % от 60 мА`) with English (`input = … % of 60 mA`) in ENM v0.2.0 WebConfig.
- Grep for Cyrillic across CT-touched firmware/WebConfig sources: clean.

## Test plan
- [x] `grep` Cyrillic over `ConfigToolPage.html` and `default_enm_223_r1/*.{ino,h,cpp}` — none
- [ ] Open Meter Options: CT util line reads `input = N % of 60 mA`


Made with [Cursor](https://cursor.com)