### PR TITLE
perf(ENM-223-R1 v0.2.0): modbus_controller throttle 0ms, update_interval 1s (match DIO)

### DIFF
--- a/ENM-223-R1/Firmware/v0.2.0/default_enm_223_r1_plc/default_enm_223_r1_plc.yaml
+++ b/ENM-223-R1/Firmware/v0.2.0/default_enm_223_r1_plc/default_enm_223_r1_plc.yaml
@@ -20,8 +20,8 @@ modbus_controller:
   - id: ${enm_id}
     address: ${enm_address}
     modbus_id: modbus_bus
-    update_interval: 3s
-    command_throttle: 50ms
+    update_interval: 1s
+    command_throttle: 0ms
     allow_duplicate_commands: false
 
 binary_sensor:


### PR DESCRIPTION
## Summary
- `modbus_controller` timing aligned with DIO: `update_interval: 1s`, `command_throttle: 0ms`.
- No map / entity / version changes.

## Test plan
- [ ] Package shows `update_interval: 1s` and `command_throttle: 0ms`
- [ ] Firmware identity (`HM_FW` / CFG / METER / HM_MAP) untouched


Made with [Cursor](https://cursor.com)