### PR TITLE
fix(WebConfig): enlarge header module photo

### DIFF
--- a/ENM-223-R1/Firmware/v0.2.0/ConfigToolPage.html
+++ b/ENM-223-R1/Firmware/v0.2.0/ConfigToolPage.html
@@ -30,12 +30,15 @@
     .hm-advanced{margin-top:1rem}
     .hm-advanced>summary{cursor:pointer;padding:.5rem 0;font-weight:600;user-select:none}
     .hm-advanced[open]>summary{margin-bottom:.75rem}
+    /* Square product shot fills the header; photo1.png is a wide banner with huge black margins */
+    .moduleImage{width:180px;height:180px;border-radius:18px;border:1px solid var(--border);display:grid;place-items:center;overflow:hidden;background:#0b0b0b;flex:0 0 auto}
+    .moduleImage img{width:100%;height:100%;object-fit:cover;object-position:center}
   </style>
 
   <header class="appbar">
     <div class="headLeft">
       <div class="moduleImage">
-        <img src="../../Images/photo1.png" alt="ENM-223-R1">
+        <img src="../../Images/ENM_2000x2000.png" alt="ENM-223-R1" width="180" height="180">
       </div>
       <div class="title">
         <h1>ENM-223-R1 Module Configuration</h1>

--- a/_shared/hm-webconfig.css
+++ b/_shared/hm-webconfig.css
@@ -76,8 +76,8 @@ textarea{min-height:140px;font-family:ui-monospace,Consolas,monospace}
 
 .appbar{display:flex;justify-content:space-between;gap:16px;padding:16px;background:var(--card);border:1px solid var(--border);border-radius:var(--r);box-shadow:var(--shadow);margin-bottom:var(--gap)}
 .headLeft{display:flex;gap:14px;align-items:center;min-width:300px}
-.moduleImage{width:96px;height:96px;border-radius:14px;border:1px solid var(--border);display:grid;place-items:center;overflow:hidden}
-.moduleImage img{width:100%;height:100%;object-fit:contain}
+.moduleImage{width:160px;height:160px;border-radius:16px;border:1px solid var(--border);display:grid;place-items:center;overflow:hidden;background:#f8fafc;flex:0 0 auto}
+.moduleImage img{width:100%;height:100%;object-fit:cover;object-position:center}
 .title h1{margin:0;font-size:18px;font-weight:800}
 .title p{margin:4px 0 0;font-size:13px;color:var(--muted)}
 .statusbar{display:flex;flex-direction:column;align-items:flex-end;gap:10px}


### PR DESCRIPTION
## Summary
- Bump shared `.moduleImage` from 96×96 to 160×160 with `object-fit: cover` so header product shots are readable across modules.
- ENM-223-R1 v0.2.0 WebConfig: use square `ENM_2000x2000.png` at 180×180 instead of the wide `photo1.png` banner (module was ~30% of that frame).

## Test plan
- [ ] Open `ENM-223-R1/Firmware/v0.2.0/ConfigToolPage.html` from GitHub Pages / config.home-master.eu after merge
- [ ] Confirm the header shows a clear ENM faceplate (green panel, terminals readable)
- [ ] Spot-check another module WebConfig (e.g. DIO/ALM) — header image larger, not cropped badly


Made with [Cursor](https://cursor.com)