### PR TITLE
fix(ENM-223-R1 v0.2.0): pin accuracy_decimals on temperature + energy sensors (clean HA display, no buyer config)

### DIFF
--- a/ENM-223-R1/Firmware/v0.2.0/default_enm_223_r1_plc/default_enm_223_r1_plc.yaml
+++ b/ENM-223-R1/Firmware/v0.2.0/default_enm_223_r1_plc/default_enm_223_r1_plc.yaml
@@ -430,6 +430,7 @@ sensor:
     register_type: read
     value_type: S_WORD
     unit_of_measurement: "°C"
+    accuracy_decimals: 0
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
     name: "${enm_prefix} PF L1"
@@ -710,6 +711,7 @@ sensor:
     unit_of_measurement: "Wh"
     device_class: energy
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -720,6 +722,7 @@ sensor:
     unit_of_measurement: "Wh"
     device_class: energy
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -730,6 +733,7 @@ sensor:
     unit_of_measurement: "Wh"
     device_class: energy
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -741,6 +745,7 @@ sensor:
     unit_of_measurement: "Wh"
     device_class: energy
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -751,6 +756,7 @@ sensor:
     unit_of_measurement: "Wh"
     device_class: energy
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -761,6 +767,7 @@ sensor:
     unit_of_measurement: "Wh"
     device_class: energy
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -771,6 +778,7 @@ sensor:
     unit_of_measurement: "Wh"
     device_class: energy
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -782,6 +790,7 @@ sensor:
     unit_of_measurement: "Wh"
     device_class: energy
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -791,6 +800,7 @@ sensor:
     value_type: U_DWORD
     unit_of_measurement: "varh"
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -800,6 +810,7 @@ sensor:
     value_type: U_DWORD
     unit_of_measurement: "varh"
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -809,6 +820,7 @@ sensor:
     value_type: U_DWORD
     unit_of_measurement: "varh"
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -819,6 +831,7 @@ sensor:
     value_type: U_DWORD
     unit_of_measurement: "varh"
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -828,6 +841,7 @@ sensor:
     value_type: U_DWORD
     unit_of_measurement: "varh"
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -837,6 +851,7 @@ sensor:
     value_type: U_DWORD
     unit_of_measurement: "varh"
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -846,6 +861,7 @@ sensor:
     value_type: U_DWORD
     unit_of_measurement: "varh"
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: modbus_controller
     modbus_controller_id: ${enm_id}
@@ -856,6 +872,7 @@ sensor:
     value_type: U_DWORD
     unit_of_measurement: "varh"
     state_class: total_increasing
+    accuracy_decimals: 0
     skip_updates: 2
   - platform: template
     name: "${enm_prefix} Active Energy Net Total"


### PR DESCRIPTION
## Summary
- Package-only YAML: pin `accuracy_decimals: 0` on Temperature (IR 11) and all 16 modbus energy counters (IR 54..84).
- Maps to HA `suggested_display_precision` at first registration so a fresh install shows integer Wh/varh/°C with no buyer-side HA config.
- Template net energy sensors left unchanged (already had `accuracy_decimals: 0`). No firmware / map / version changes.

## Test plan
- [ ] `grep -c accuracy_decimals` = 49 (was 32, +17)
- [ ] Diff is additions only on the YAML package
- [ ] Flash/adopt package in HA; Temperature and energy entities show 0 decimal places without entity customization


Made with [Cursor](https://cursor.com)