### PR TITLE
docs(ENM-223-R1): polish README subsections to match DIO (dedup §5.4, renumber §8, §7/§10/§12)

### DIFF
--- a/ENM-223-R1/README.md
+++ b/ENM-223-R1/README.md
@@ -148,6 +148,8 @@ Detailed WebConfig steps for these patterns are in [§6 WebConfig Reference](#6-
 | **Weight** | ~420 g |
 | **Terminals** | 300 V / 20 A / 26–12 AWG (2.5 mm²) / torque 0.5–0.6 Nm / pitch 5.08 mm |
 | **Ingress Protection** | IP20 (EN 60529) |
+| **Altitude** | ≤ 2000 m |
+| **Environment** | RoHS / REACH compliant |
 | **Operating Temp.** | 0–40 °C / ≤95 % RH (non-condensing) |
 
 <div align="center">
@@ -184,11 +186,7 @@ The module communicates over **RS-485 Modbus RTU** (A/B differential + shared CO
 
 ### Standards & compliance
 
-| Standard / Directive | Description |
-|----------------------|-------------|
-| **Ingress Rating** | IP20 (panel mount only) |
-| **Altitude Limit** | ≤ 2000 m |
-| **Environment** | RoHS / REACH compliant |
+See [§12 Compliance & Certifications](#12-compliance--certifications) for directives, DoC, and related marks. Mechanical ingress (IP20) is also listed under [§3.3](#33-mechanical--environmental).
 
 ---
 
@@ -293,7 +291,7 @@ These safety guidelines apply to the **ENM‑223‑R1 3‑phase metering and I/O
 
 #### I/O & interface warnings
 
-#### ⚡ Power
+#### Power
 
 | Area             | Warning |
 |------------------|---------|
@@ -301,27 +299,27 @@ These safety guidelines apply to the **ENM‑223‑R1 3‑phase metering and I/O
 | **Voltage Input** | Connect **L1/L2/L3/N/PE** only within rated range (85–265 V AC). Use circuit protection upstream. |
 | **Sensor Domain** | Use **CTs with 1 V or 333 mV RMS** output. Never apply 5 A directly. Observe polarity and shielding. |
 
-#### 🧲 Inputs & Relays
+#### Inputs & Relays
 
 | Area              | Warning |
 |-------------------|---------|
 | **CT Inputs**      | Accept only voltage-output CTs. Reversing polarity may affect power sign. Use GND_ISO reference. |
 | **Relay Outputs**  | Dry contacts only. Rated: **3 A @ 250 VAC or 30 VDC** (module limit). Use snubber (RC/TVS) for inductive loads. |
 
-#### 🖧 Communication & USB
+#### Communication & USB
 
 | Area            | Warning |
 |-----------------|---------|
 | **RS‑485 Bus**   | Use **twisted pair**. Terminate at both ends. Match A/B polarity. Share GND if powered from different PSUs. |
 | **USB-C (Front)**| For **setup only**. Not for permanent field connection. Disconnect during storms or long idle periods. |
 
-#### 🎛 Front Panel
+#### Front Panel
 
 | Area               | Warning |
 |--------------------|---------|
 | **Buttons & LEDs** | Buttons toggle relays in Modbus mode only. Use **Alarm Controlled** relays for safety interlocks. |
 
-#### 🛡 Shielding & EMC
+#### Shielding & EMC
 
 | Area             | Recommendation |
 |------------------|----------------|
@@ -404,7 +402,7 @@ The ENM‑223‑R1 uses **24 V DC** input for its interface domain and interna
 
 Mount the module on a **35 mm DIN rail** inside a suitable enclosure; only qualified personnel may wire **mains voltage**, **CT**, or relay load circuits. Do **not** bond **GND** (logic) to **GND_ISO** (metering domain).
 
-#### Power (24 V DC)
+##### Power (24 V DC)
 
 Connect a regulated **24 V DC SELV** supply to **V+** and **0V** for MCU, RS-485, relays, and status LEDs (reverse-polarity protected; typical 50–150 mA).
 
@@ -412,7 +410,7 @@ Connect a regulated **24 V DC SELV** supply to **V+** and **0V** for MCU, RS-485
 
 *Regulated **24 V DC** to **V+** / **0V** — fuse the feed upstream per local rules.*
 
-#### 3-phase voltage inputs
+##### 3-phase voltage inputs
 
 Wire **L1**, **L2**, **L3**, **N**, and **PE** to the voltage-sensing terminals for your **3P4W** or **3P3W** installation — these terminals can carry hazardous mains voltage.
 
@@ -420,7 +418,7 @@ Wire **L1**, **L2**, **L3**, **N**, and **PE** to the voltage-sensing terminals 
 
 *Phase and neutral sensing inputs per terminal map; set wiring scheme and phase mapping in WebConfig.*
 
-#### Current transformers (CT)
+##### Current transformers (CT)
 
 Connect external CT secondary pairs to **CT1**, **CT2**, and **CT3** with correct polarity and the rated output level (333 mV or 1 V RMS).
 
@@ -428,7 +426,7 @@ Connect external CT secondary pairs to **CT1**, **CT2**, and **CT3** with correc
 
 *Shielded CT leads recommended; observe arrow polarity for correct signed power readings.*
 
-#### Relays (2× SPDT)
+##### Relays (2× SPDT)
 
 Two **SPDT** dry-contact relays (**NO** / **COM** / **NC**) switch external loads at up to **3 A @ 250 VAC** (module/PCB limit); provide external fusing and RC snubbers on inductive circuits.
 
@@ -436,83 +434,45 @@ Two **SPDT** dry-contact relays (**NO** / **COM** / **NC**) switch external load
 
 *Dry contacts only — external load supply and overcurrent protection are mandatory.*
 
-#### RS-485 (Modbus RTU)
+##### RS-485 (Modbus RTU)
 
-Wire **A**, **B**, and **COM** on twisted-pair cable in a daisy-chain bus; place **120 Ω** termination at the physical ends of the segment.
-
-<img src="https://raw.githubusercontent.com/isystemsautomation/homemaster-dev/main/ENM-223-R1/Images/ENM_RS485.png" width="440" alt="RS-485 A/B/COM Modbus wiring">
-
-***A** → A, **B** → B, **COM** → reference ground as required by the network.*
-
-#### USB-C
-
-The **USB-C** port is for **WebConfig** setup and firmware update only (5 V from the host PC, logic domain); it is **not** a field power or runtime data bus — disconnect USB before energising the installation and before handing control to RS-485.
-
-#### RS‑485 (Modbus RTU)
-
-#### Physical
+Wire **A**, **B**, and **COM** on twisted-pair cable in a daisy-chain bus; place **120 Ω** termination at the physical ends of the segment (not inside the module). Biasing resistors (pull-up/down) belong on the master. Tie **COM/GND** references if nodes use separate supplies.
 
 | Terminals  | Description            |
 |------------|------------------------|
 | `A`, `B`   | Differential signal pair (twisted/shielded) |
 | `COM`/`GND` | Logic reference (tie GNDs if on separate supplies) |
 
-#### Cable & Topology
+Factory first-boot defaults: Modbus address **`3`**, baud **`19200`**, format **`8N1`**, address range **1–247** (set per site in WebConfig).
 
-- Twisted pair (with or without shield)
-- Terminate with **120 Ω** at each bus end (not inside module)
-- Biasing resistors (pull-up/down) should be on the master
+<img src="https://raw.githubusercontent.com/isystemsautomation/homemaster-dev/main/ENM-223-R1/Images/ENM_RS485.png" width="440" alt="RS-485 A/B/COM Modbus wiring">
 
-#### Defaults
-
-| Setting       | Value        |
-|---------------|--------------|
-| Modbus Address | `3` (first boot; set per site in WebConfig) |
-| Baud Rate      | `19200` |
-| Format         | `8N1` |
-| Address Range  | 1–247 |
+***A** → A, **B** → B, **COM** → reference ground as required by the network.*
 
 > 🧷 Reversed A/B will cause CRC errors — check if no response.
 
----
+##### USB-C
 
-#### USB‑C (WebConfig)
-
-**Purpose:** Web-based configuration tool over native USB Serial. Supports:
-- Live readings
-- Address/baudrate config
-- Phase mapping
-- Relay/button/LED logic
-- Alarm setup
-- Calibration (gains/offsets)
-
-#### Steps
-
-1. Connect USB‑C to PC (Chromium-based browser)
-2. Open `Firmware/v0.2.0/ConfigToolPage.html`  
-3. Click **Connect**, select ENM serial port  
-4. Configure settings: address, relays, LEDs, alarms, calibration  
-5. Click **Save & Disconnect** when finished
-
-> ⚠️ If **Connect** is greyed out: check browser support, OS permissions, and close any other apps using the port.
+The **USB-C** port is for **WebConfig** setup and firmware update only (5 V from the host PC, logic domain); it is **not** a field power or runtime data bus — disconnect USB before energising the installation and before handing control to RS-485.
 
 #### Configure (WebConfig)
-
 
 - Open `Firmware/v0.2.0/ConfigToolPage.html` in a Chromium-based browser (Chrome, Edge, Opera, Brave, Vivaldi)
 - Connect via **USB‑C** → **Select port → Connect**
 - Set:
   - **Modbus Address / Baud**  
-  - **Line frequency, sum mode, 3P4W/3P3W, phase mapping**
-  - **Alarm thresholds** per L1/L2/L3/Totals
-  - **Relay modes**: Alarm or Modbus Controlled
-  - Map **Buttons & LEDs** (relay toggle / status)
+  - **Line frequency, sum mode, 3P4W/3P3W, phase mapping**, CT ratio / PGA  
+  - **Alarm thresholds** per L1/L2/L3/Totals  
+  - **Relay modes**: Alarm or Modbus Controlled  
+  - Map **Buttons & LEDs** (relay toggle / Ack / status)  
   - (Optional) Adjust **U/I gains**, save calibration
+- Disconnect USB when finished; hand control to the RS-485 master
 
 👉 See: [WebConfig UI](#6-webconfig-reference)
 
-#### Integrate (Controller)
+> ⚠️ If **Connect** is greyed out: check browser support, OS permissions, and close any other apps using the port.
 
+#### Integrate (Controller)
 
 - Connect controller via **RS‑485**
 - Match **Modbus address / baud**
@@ -722,14 +682,7 @@ Toggle actions apply when the target relay is **Modbus Controlled**. Ack actions
 
 ## 7. Modbus Register Map
 
-The ENM‑223‑R1 is a **Modbus RTU slave** on RS‑485. Firmware **v0.2.0** exposes a **contiguous** map designed for **one FC04 sweep**:
-
-| Area | Detail |
-|------|--------|
-| **FC04** Input Registers | **`0..85`** (86 registers) — I/O mask, status, alarms, chip events, scalars, S32 currents/powers, U32 energies |
-| **FC01 / FC05** Coils | Write-only commands: relays **0/1**, Identify **5**, ACK **16–19** |
-| **FC03 / FC06 / FC16** Holding | Address, baud, line frequency, sum-abs, relay enable (HR **0..8**, 3 & 6 reserved) |
-| **FC02** Discrete Inputs | **Not used** — digital state is bit-packed into input registers |
+The ENM‑223‑R1 is a **Modbus RTU slave** on RS‑485. Firmware **v0.2.0** exposes a **contiguous** map designed for **one FC04 sweep**.
 
 | Setting | Value |
 |---------|-------|
@@ -739,7 +692,16 @@ The ENM‑223‑R1 is a **Modbus RTU slave** on RS‑485. Firmware **v0.2.0** ex
 
 > Full addresses, types, scales and bit layouts: **[Modbus_Table.md](Modbus_Table.md)**.
 
-### 7.1 Map summary (FC04)
+### 7.1 Address map (overview)
+
+| Area | Detail |
+|------|--------|
+| **FC04** Input Registers | **`0..85`** (86 registers) — I/O mask, status, alarms, chip events, scalars, S32 currents/powers, U32 energies |
+| **FC01 / FC05** Coils | Write-only commands: relays **0/1**, Identify **5**, ACK **16–19** |
+| **FC03 / FC06 / FC16** Holding | Address, baud, line frequency, sum-abs, relay enable (HR **0..8**, 3 & 6 reserved) |
+| **FC02** Discrete Inputs | **Not used** — digital state is bit-packed into input registers |
+
+### 7.2 Input Registers (FC04)
 
 | Addr | Content |
 |------|---------|
@@ -752,7 +714,7 @@ The ENM‑223‑R1 is a **Modbus RTU slave** on RS‑485. Firmware **v0.2.0** ex
 | 30–52 | P / Q / S L1–Total (**S32**) |
 | 54–84 | Active/reactive import & export energy (**U32** Wh/varh, primary) |
 
-### 7.2 Coils (write-only)
+### 7.3 Coils (write-only)
 
 | Addr | Coil |
 |------|------|
@@ -762,7 +724,7 @@ The ENM‑223‑R1 is a **Modbus RTU slave** on RS‑485. Firmware **v0.2.0** ex
 
 Reboot, save-config and energy-reset are **not** on Modbus — use WebConfig.
 
-### 7.3 Holding registers
+### 7.4 Holding registers
 
 | Addr | Field |
 |------|-------|
@@ -772,13 +734,13 @@ Reboot, save-config and energy-reset are **not** on Modbus — use WebConfig.
 | 5 | Sum-abs mode |
 | 7–8 | Relay 1 / 2 enable |
 
-### 7.4 Polling
+### 7.5 Polling
 
 - Prefer **one FC04** of `0..85` at ~1 s for live data.
 - Energy (54–84) may be polled less often; the ESPHome package uses `skip_updates: 2` on energy sensors.
 - Stagger multiple ENMs on a shared bus (unique IDs, end-of-line termination).
 
-### 7.5 Integrator note (upgrading from v0.1.0)
+### 7.6 Integrator note (upgrading from v0.1.0)
 
 The map is **not** a drop-in for masters that still poll discrete inputs, peaks on Modbus, or addresses above 85. Point ESPHome at the v0.2.0 package and regenerate entities.
 
@@ -890,7 +852,7 @@ Holding registers are not mirrored as HA entities in the package (configure bus 
 
 ---
 
-### 8.6 Using Your MiniPLC YAML with ENM
+### 8.5 Using Your MiniPLC YAML with ENM
 
 1. Keep existing `uart:` and `modbus:` blocks  
 2. Add the `packages:` block (as shown) and set `enm_address` from WebConfig  
@@ -899,7 +861,7 @@ Holding registers are not mirrored as HA entities in the package (configure bus 
 
 ---
 
-### 8.7 Home Assistant Setup & Automations
+### 8.6 Home Assistant Setup & Automations
 
 - Go to: **Settings → Devices & Services → ESPHome → Add** by hostname or IP
 - Dashboard auto-discovers:
@@ -984,6 +946,20 @@ Recommission alarms, relay modes, bus address, and phase mapping in WebConfig af
 ---
 
 ## 10. Maintenance & Troubleshooting
+
+### 10.1 Status LEDs
+
+- **PWR** — ON in normal operation
+- **TX/RX** — blink on Modbus traffic
+- **User LEDs (1–4)** — follow configured source / mode in [§6 WebConfig](#6-webconfig-reference)
+
+### 10.2 Resets
+
+- **Power cycle:** remove 24 V, wait, re-apply
+- **Buttons 1 + 2** — enter **BOOT** mode for UF2 flashing
+- **Buttons 3 + 4** — hardware **RESET**
+
+### 10.3 Common issues
 
 | Symptom               | Fix or Explanation                            |
 |------------------------|-----------------------------------------------|

--- a/ENM-223-R1/readme.html
+++ b/ENM-223-R1/readme.html
@@ -110,8 +110,7 @@ blockquote table{background:transparent}
 </style>
 </head>
 <body>
-  <div class="site-wrap">
-    <article class="card">
+  <div class="site-wrap"><article class="card">
 <p><img src="https://img.shields.io/badge/Protocol-Modbus%20RTU-brightgreen" alt="Modbus"></p>
 <p><img src="https://img.shields.io/badge/License-GPLv3%20%2F%20CERN--OHL--W-blue" alt="License"></p>
 <h1 id="enm-223-r1--3-phase-power-metering--io-module">ENM-223-R1 — 3-Phase Power Metering & I/O Module</h1>
@@ -249,6 +248,8 @@ blockquote table{background:transparent}
 <tr><td><strong>Weight</strong></td><td>~420 g</td></tr>
 <tr><td><strong>Terminals</strong></td><td>300 V / 20 A / 26–12 AWG (2.5 mm²) / torque 0.5–0.6 Nm / pitch 5.08 mm</td></tr>
 <tr><td><strong>Ingress Protection</strong></td><td>IP20 (EN 60529)</td></tr>
+<tr><td><strong>Altitude</strong></td><td>≤ 2000 m</td></tr>
+<tr><td><strong>Environment</strong></td><td>RoHS / REACH compliant</td></tr>
 <tr><td><strong>Operating Temp.</strong></td><td>0–40 °C / ≤95 % RH (non-condensing)</td></tr>
 </tbody>
 </table>
@@ -282,13 +283,7 @@ blockquote table{background:transparent}
 <li><strong>Memory Retention:</strong> <strong>LittleFS</strong> — settings <code>/enm_cfg.bin</code>, meter <code>/enm_meter.bin</code> (see <a href="Firmware/README.md">Firmware/README</a>)</li>
 </ul>
 <h3 id="standards--compliance">Standards & compliance</h3>
-<table>
-<thead><tr><th>Standard / Directive</th><th>Description</th></tr></thead><tbody>
-<tr><td><strong>Ingress Rating</strong></td><td>IP20 (panel mount only)</td></tr>
-<tr><td><strong>Altitude Limit</strong></td><td>≤ 2000 m</td></tr>
-<tr><td><strong>Environment</strong></td><td>RoHS / REACH compliant</td></tr>
-</tbody>
-</table>
+<p>See <a href="#12-compliance--certifications">§12 Compliance & Certifications</a> for directives, DoC, and related marks. Mechanical ingress (IP20) is also listed under <a href="#33-mechanical--environmental">§3.3</a>.</p>
 <hr>
 <h2 id="4-hardware--interface">4. Hardware & Interface</h2>
 <h3 id="41-diagrams--pinouts">4.1 Diagrams & pinouts</h3>
@@ -377,7 +372,7 @@ blockquote table{background:transparent}
 </table>
 <hr>
 <h4 id="io--interface-warnings">I/O & interface warnings</h4>
-<h4 id="power">⚡ Power</h4>
+<h4 id="power">Power</h4>
 <table>
 <thead><tr><th>Area</th><th>Warning</th></tr></thead><tbody>
 <tr><td><strong>24 V DC Input</strong></td><td>Use a clean, fused SELV power source. Reverse polarity is protected but may disable the module.</td></tr>
@@ -385,27 +380,27 @@ blockquote table{background:transparent}
 <tr><td><strong>Sensor Domain</strong></td><td>Use <strong>CTs with 1 V or 333 mV RMS</strong> output. Never apply 5 A directly. Observe polarity and shielding.</td></tr>
 </tbody>
 </table>
-<h4 id="inputs--relays">🧲 Inputs & Relays</h4>
+<h4 id="inputs--relays">Inputs & Relays</h4>
 <table>
 <thead><tr><th>Area</th><th>Warning</th></tr></thead><tbody>
 <tr><td><strong>CT Inputs</strong></td><td>Accept only voltage-output CTs. Reversing polarity may affect power sign. Use GND_ISO reference.</td></tr>
 <tr><td><strong>Relay Outputs</strong></td><td>Dry contacts only. Rated: <strong>3 A @ 250 VAC or 30 VDC</strong> (module limit). Use snubber (RC/TVS) for inductive loads.</td></tr>
 </tbody>
 </table>
-<h4 id="communication--usb">🖧 Communication & USB</h4>
+<h4 id="communication--usb">Communication & USB</h4>
 <table>
 <thead><tr><th>Area</th><th>Warning</th></tr></thead><tbody>
 <tr><td><strong>RS‑485 Bus</strong></td><td>Use <strong>twisted pair</strong>. Terminate at both ends. Match A/B polarity. Share GND if powered from different PSUs.</td></tr>
 <tr><td><strong>USB-C (Front)</strong></td><td>For <strong>setup only</strong>. Not for permanent field connection. Disconnect during storms or long idle periods.</td></tr>
 </tbody>
 </table>
-<h4 id="front-panel">🎛 Front Panel</h4>
+<h4 id="front-panel">Front Panel</h4>
 <table>
 <thead><tr><th>Area</th><th>Warning</th></tr></thead><tbody>
 <tr><td><strong>Buttons & LEDs</strong></td><td>Buttons toggle relays in Modbus mode only. Use <strong>Alarm Controlled</strong> relays for safety interlocks.</td></tr>
 </tbody>
 </table>
-<h4 id="shielding--emc">🛡 Shielding & EMC</h4>
+<h4 id="shielding--emc">Shielding & EMC</h4>
 <table>
 <thead><tr><th>Area</th><th>Recommendation</th></tr></thead><tbody>
 <tr><td><strong>Cable Shields</strong></td><td>Terminate at one side only (preferably PLC/controller). Route away from VFDs and high-voltage cabling.</td></tr>
@@ -486,89 +481,55 @@ Set <strong>Address/Baud</strong> → assign <strong>Inputs/Relays/LEDs</strong>
 <li>Ground panel PE and avoid bridging <strong>GND ↔ GND_ISO</strong></li>
 </ul>
 <p>Mount the module on a <strong>35 mm DIN rail</strong> inside a suitable enclosure; only qualified personnel may wire <strong>mains voltage</strong>, <strong>CT</strong>, or relay load circuits. Do <strong>not</strong> bond <strong>GND</strong> (logic) to <strong>GND_ISO</strong> (metering domain).</p>
-<h4 id="power-24-v-dc">Power (24 V DC)</h4>
+<h5 id="power-24-v-dc">Power (24 V DC)</h5>
 <p>Connect a regulated <strong>24 V DC SELV</strong> supply to <strong>V+</strong> and <strong>0V</strong> for MCU, RS-485, relays, and status LEDs (reverse-polarity protected; typical 50–150 mA).</p>
 <img src="https://raw.githubusercontent.com/isystemsautomation/homemaster-dev/main/ENM-223-R1/Images/ENM_24Vdc.png" width="440" alt="24 V DC power wiring to V+ and 0V">
 <p><em>Regulated <strong>24 V DC</strong> to <strong>V+</strong> / <strong>0V</strong> — fuse the feed upstream per local rules.</em></p>
-<h4 id="3-phase-voltage-inputs">3-phase voltage inputs</h4>
+<h5 id="3-phase-voltage-inputs">3-phase voltage inputs</h5>
 <p>Wire <strong>L1</strong>, <strong>L2</strong>, <strong>L3</strong>, <strong>N</strong>, and <strong>PE</strong> to the voltage-sensing terminals for your <strong>3P4W</strong> or <strong>3P3W</strong> installation — these terminals can carry hazardous mains voltage.</p>
 <img src="https://raw.githubusercontent.com/isystemsautomation/homemaster-dev/main/ENM-223-R1/Images/ENM_PhaseConnection.png" width="440" alt="3-phase voltage input wiring L1/L2/L3-N/PE">
 <p><em>Phase and neutral sensing inputs per terminal map; set wiring scheme and phase mapping in WebConfig.</em></p>
-<h4 id="current-transformers-ct">Current transformers (CT)</h4>
+<h5 id="current-transformers-ct">Current transformers (CT)</h5>
 <p>Connect external CT secondary pairs to <strong>CT1</strong>, <strong>CT2</strong>, and <strong>CT3</strong> with correct polarity and the rated output level (333 mV or 1 V RMS).</p>
 <img src="https://raw.githubusercontent.com/isystemsautomation/homemaster-dev/main/ENM-223-R1/Images/ENM_CTConnection.png" width="440" alt="Current transformer CT1/CT2/CT3 wiring">
 <p><em>Shielded CT leads recommended; observe arrow polarity for correct signed power readings.</em></p>
-<h4 id="relays-2-spdt">Relays (2× SPDT)</h4>
+<h5 id="relays-2-spdt">Relays (2× SPDT)</h5>
 <p>Two <strong>SPDT</strong> dry-contact relays (<strong>NO</strong> / <strong>COM</strong> / <strong>NC</strong>) switch external loads at up to <strong>3 A @ 250 VAC</strong> (module/PCB limit); provide external fusing and RC snubbers on inductive circuits.</p>
 <img src="https://raw.githubusercontent.com/isystemsautomation/homemaster-dev/main/ENM-223-R1/Images/ENM_RelayConnection.png" width="440" alt="Relay NO/COM/NC wiring">
 <p><em>Dry contacts only — external load supply and overcurrent protection are mandatory.</em></p>
-<h4 id="rs-485-modbus-rtu">RS-485 (Modbus RTU)</h4>
-<p>Wire <strong>A</strong>, <strong>B</strong>, and <strong>COM</strong> on twisted-pair cable in a daisy-chain bus; place <strong>120 Ω</strong> termination at the physical ends of the segment.</p>
-<img src="https://raw.githubusercontent.com/isystemsautomation/homemaster-dev/main/ENM-223-R1/Images/ENM_RS485.png" width="440" alt="RS-485 A/B/COM Modbus wiring">
-<p><strong><em>A</strong> → A, <strong>B</strong> → B, <strong>COM</strong> → reference ground as required by the network.</em></p>
-<h4 id="usb-c">USB-C</h4>
-<p>The <strong>USB-C</strong> port is for <strong>WebConfig</strong> setup and firmware update only (5 V from the host PC, logic domain); it is <strong>not</strong> a field power or runtime data bus — disconnect USB before energising the installation and before handing control to RS-485.</p>
-<h4 id="rs485-modbus-rtu">RS‑485 (Modbus RTU)</h4>
-<h4 id="physical">Physical</h4>
+<h5 id="rs-485-modbus-rtu">RS-485 (Modbus RTU)</h5>
+<p>Wire <strong>A</strong>, <strong>B</strong>, and <strong>COM</strong> on twisted-pair cable in a daisy-chain bus; place <strong>120 Ω</strong> termination at the physical ends of the segment (not inside the module). Biasing resistors (pull-up/down) belong on the master. Tie <strong>COM/GND</strong> references if nodes use separate supplies.</p>
 <table>
 <thead><tr><th>Terminals</th><th>Description</th></tr></thead><tbody>
 <tr><td><code>A</code>, <code>B</code></td><td>Differential signal pair (twisted/shielded)</td></tr>
 <tr><td><code>COM</code>/<code>GND</code></td><td>Logic reference (tie GNDs if on separate supplies)</td></tr>
 </tbody>
 </table>
-<h4 id="cable--topology">Cable & Topology</h4>
-<ul>
-<li>Twisted pair (with or without shield)</li>
-<li>Terminate with <strong>120 Ω</strong> at each bus end (not inside module)</li>
-<li>Biasing resistors (pull-up/down) should be on the master</li>
-</ul>
-<h4 id="defaults">Defaults</h4>
-<table>
-<thead><tr><th>Setting</th><th>Value</th></tr></thead><tbody>
-<tr><td>Modbus Address</td><td><code>3</code> (first boot; set per site in WebConfig)</td></tr>
-<tr><td>Baud Rate</td><td><code>19200</code></td></tr>
-<tr><td>Format</td><td><code>8N1</code></td></tr>
-<tr><td>Address Range</td><td>1–247</td></tr>
-</tbody>
-</table>
+<p>Factory first-boot defaults: Modbus address <strong><code>3</code></strong>, baud <strong><code>19200</code></strong>, format <strong><code>8N1</code></strong>, address range <strong>1–247</strong> (set per site in WebConfig).</p>
+<img src="https://raw.githubusercontent.com/isystemsautomation/homemaster-dev/main/ENM-223-R1/Images/ENM_RS485.png" width="440" alt="RS-485 A/B/COM Modbus wiring">
+<p><strong><em>A</strong> → A, <strong>B</strong> → B, <strong>COM</strong> → reference ground as required by the network.</em></p>
 <blockquote>
 <p>🧷 Reversed A/B will cause CRC errors — check if no response.</p>
 </blockquote>
-<hr>
-<h4 id="usbc-webconfig">USB‑C (WebConfig)</h4>
-<p><strong>Purpose:</strong> Web-based configuration tool over native USB Serial. Supports:</p>
-<ul>
-<li>Live readings</li>
-<li>Address/baudrate config</li>
-<li>Phase mapping</li>
-<li>Relay/button/LED logic</li>
-<li>Alarm setup</li>
-<li>Calibration (gains/offsets)</li>
-</ul>
-<h4 id="steps">Steps</h4>
-<ol>
-<li>Connect USB‑C to PC (Chromium-based browser)</li>
-<li>Open <code>Firmware/v0.2.0/ConfigToolPage.html</code>  </li>
-<li>Click <strong>Connect</strong>, select ENM serial port  </li>
-<li>Configure settings: address, relays, LEDs, alarms, calibration  </li>
-<li>Click <strong>Save & Disconnect</strong> when finished</li>
-</ol>
-<blockquote>
-<p>⚠️ If <strong>Connect</strong> is greyed out: check browser support, OS permissions, and close any other apps using the port.</p>
-</blockquote>
+<h5 id="usb-c">USB-C</h5>
+<p>The <strong>USB-C</strong> port is for <strong>WebConfig</strong> setup and firmware update only (5 V from the host PC, logic domain); it is <strong>not</strong> a field power or runtime data bus — disconnect USB before energising the installation and before handing control to RS-485.</p>
 <h4 id="configure-webconfig">Configure (WebConfig)</h4>
 <ul>
 <li>Open <code>Firmware/v0.2.0/ConfigToolPage.html</code> in a Chromium-based browser (Chrome, Edge, Opera, Brave, Vivaldi)</li>
 <li>Connect via <strong>USB‑C</strong> → <strong>Select port → Connect</strong></li>
 <li>Set:</li>
 <li><strong>Modbus Address / Baud</strong>  </li>
-<li><strong>Line frequency, sum mode, 3P4W/3P3W, phase mapping</strong></li>
-<li><strong>Alarm thresholds</strong> per L1/L2/L3/Totals</li>
-<li><strong>Relay modes</strong>: Alarm or Modbus Controlled</li>
-<li>Map <strong>Buttons & LEDs</strong> (relay toggle / status)</li>
+<li><strong>Line frequency, sum mode, 3P4W/3P3W, phase mapping</strong>, CT ratio / PGA  </li>
+<li><strong>Alarm thresholds</strong> per L1/L2/L3/Totals  </li>
+<li><strong>Relay modes</strong>: Alarm or Modbus Controlled  </li>
+<li>Map <strong>Buttons & LEDs</strong> (relay toggle / Ack / status)  </li>
 <li>(Optional) Adjust <strong>U/I gains</strong>, save calibration</li>
+<li>Disconnect USB when finished; hand control to the RS-485 master</li>
 </ul>
 <p>👉 See: <a href="#6-webconfig-reference">WebConfig UI</a></p>
+<blockquote>
+<p>⚠️ If <strong>Connect</strong> is greyed out: check browser support, OS permissions, and close any other apps using the port.</p>
+</blockquote>
 <h4 id="integrate-controller">Integrate (Controller)</h4>
 <ul>
 <li>Connect controller via <strong>RS‑485</strong></li>
@@ -743,15 +704,7 @@ Set <strong>Address/Baud</strong> → assign <strong>Inputs/Relays/LEDs</strong>
 <p><strong>Override R1 / Override R2</strong> follow relay 1/2 logical state. Alarm / Warning / Event sources follow latched alarm state per channel (as labelled in the tool).</p>
 <hr>
 <h2 id="7-modbus-register-map">7. Modbus Register Map</h2>
-<p>The ENM‑223‑R1 is a <strong>Modbus RTU slave</strong> on RS‑485. Firmware <strong>v0.2.0</strong> exposes a <strong>contiguous</strong> map designed for <strong>one FC04 sweep</strong>:</p>
-<table>
-<thead><tr><th>Area</th><th>Detail</th></tr></thead><tbody>
-<tr><td><strong>FC04</strong> Input Registers</td><td><strong><code>0..85</code></strong> (86 registers) — I/O mask, status, alarms, chip events, scalars, S32 currents/powers, U32 energies</td></tr>
-<tr><td><strong>FC01 / FC05</strong> Coils</td><td>Write-only commands: relays <strong>0/1</strong>, Identify <strong>5</strong>, ACK <strong>16–19</strong></td></tr>
-<tr><td><strong>FC03 / FC06 / FC16</strong> Holding</td><td>Address, baud, line frequency, sum-abs, relay enable (HR <strong>0..8</strong>, 3 & 6 reserved)</td></tr>
-<tr><td><strong>FC02</strong> Discrete Inputs</td><td><strong>Not used</strong> — digital state is bit-packed into input registers</td></tr>
-</tbody>
-</table>
+<p>The ENM‑223‑R1 is a <strong>Modbus RTU slave</strong> on RS‑485. Firmware <strong>v0.2.0</strong> exposes a <strong>contiguous</strong> map designed for <strong>one FC04 sweep</strong>.</p>
 <table>
 <thead><tr><th>Setting</th><th>Value</th></tr></thead><tbody>
 <tr><td>Default address</td><td><strong><code>3</code></strong> first boot (configurable <strong>1–247</strong>)</td></tr>
@@ -762,7 +715,16 @@ Set <strong>Address/Baud</strong> → assign <strong>Inputs/Relays/LEDs</strong>
 <blockquote>
 <p>Full addresses, types, scales and bit layouts: <strong><a href="Modbus_Table.md">Modbus_Table.md</a></strong>.</p>
 </blockquote>
-<h3 id="71-map-summary-fc04">7.1 Map summary (FC04)</h3>
+<h3 id="71-address-map-overview">7.1 Address map (overview)</h3>
+<table>
+<thead><tr><th>Area</th><th>Detail</th></tr></thead><tbody>
+<tr><td><strong>FC04</strong> Input Registers</td><td><strong><code>0..85</code></strong> (86 registers) — I/O mask, status, alarms, chip events, scalars, S32 currents/powers, U32 energies</td></tr>
+<tr><td><strong>FC01 / FC05</strong> Coils</td><td>Write-only commands: relays <strong>0/1</strong>, Identify <strong>5</strong>, ACK <strong>16–19</strong></td></tr>
+<tr><td><strong>FC03 / FC06 / FC16</strong> Holding</td><td>Address, baud, line frequency, sum-abs, relay enable (HR <strong>0..8</strong>, 3 & 6 reserved)</td></tr>
+<tr><td><strong>FC02</strong> Discrete Inputs</td><td><strong>Not used</strong> — digital state is bit-packed into input registers</td></tr>
+</tbody>
+</table>
+<h3 id="72-input-registers-fc04">7.2 Input Registers (FC04)</h3>
 <table>
 <thead><tr><th>Addr</th><th>Content</th></tr></thead><tbody>
 <tr><td>0</td><td>I/O mask (LEDs, buttons, <strong>relay state</strong> bits 8/9)</td></tr>
@@ -775,7 +737,7 @@ Set <strong>Address/Baud</strong> → assign <strong>Inputs/Relays/LEDs</strong>
 <tr><td>54–84</td><td>Active/reactive import & export energy (<strong>U32</strong> Wh/varh, primary)</td></tr>
 </tbody>
 </table>
-<h3 id="72-coils-write-only">7.2 Coils (write-only)</h3>
+<h3 id="73-coils-write-only">7.3 Coils (write-only)</h3>
 <table>
 <thead><tr><th>Addr</th><th>Coil</th></tr></thead><tbody>
 <tr><td>0 / 1</td><td>Relay 1 / 2 command (state from IR0)</td></tr>
@@ -784,7 +746,7 @@ Set <strong>Address/Baud</strong> → assign <strong>Inputs/Relays/LEDs</strong>
 </tbody>
 </table>
 <p>Reboot, save-config and energy-reset are <strong>not</strong> on Modbus — use WebConfig.</p>
-<h3 id="73-holding-registers">7.3 Holding registers</h3>
+<h3 id="74-holding-registers">7.4 Holding registers</h3>
 <table>
 <thead><tr><th>Addr</th><th>Field</th></tr></thead><tbody>
 <tr><td>0</td><td>Modbus address</td></tr>
@@ -794,13 +756,13 @@ Set <strong>Address/Baud</strong> → assign <strong>Inputs/Relays/LEDs</strong>
 <tr><td>7–8</td><td>Relay 1 / 2 enable</td></tr>
 </tbody>
 </table>
-<h3 id="74-polling">7.4 Polling</h3>
+<h3 id="75-polling">7.5 Polling</h3>
 <ul>
 <li>Prefer <strong>one FC04</strong> of <code>0..85</code> at ~1 s for live data.</li>
 <li>Energy (54–84) may be polled less often; the ESPHome package uses <code>skip_updates: 2</code> on energy sensors.</li>
 <li>Stagger multiple ENMs on a shared bus (unique IDs, end-of-line termination).</li>
 </ul>
-<h3 id="75-integrator-note-upgrading-from-v010">7.5 Integrator note (upgrading from v0.1.0)</h3>
+<h3 id="76-integrator-note-upgrading-from-v010">7.6 Integrator note (upgrading from v0.1.0)</h3>
 <p>The map is <strong>not</strong> a drop-in for masters that still poll discrete inputs, peaks on Modbus, or addresses above 85. Point ESPHome at the v0.2.0 package and regenerate entities.</p>
 <pre><code>modbus_controller:
   - id: enm223
@@ -897,7 +859,7 @@ packages:
 </ul>
 <p>Holding registers are not mirrored as HA entities in the package (configure bus options in WebConfig).</p>
 <hr>
-<h3 id="86-using-your-miniplc-yaml-with-enm">8.6 Using Your MiniPLC YAML with ENM</h3>
+<h3 id="85-using-your-miniplc-yaml-with-enm">8.5 Using Your MiniPLC YAML with ENM</h3>
 <ol>
 <li>Keep existing <code>uart:</code> and <code>modbus:</code> blocks  </li>
 <li>Add the <code>packages:</code> block (as shown) and set <code>enm_address</code> from WebConfig  </li>
@@ -905,7 +867,7 @@ packages:
 <li>Add HA dashboard cards and <code>switches</code> for relay control and alarm acknowledge  </li>
 </ol>
 <hr>
-<h3 id="87-home-assistant-setup--automations">8.7 Home Assistant Setup & Automations</h3>
+<h3 id="86-home-assistant-setup--automations">8.6 Home Assistant Setup & Automations</h3>
 <ul>
 <li>Go to: <strong>Settings → Devices & Services → ESPHome → Add</strong> by hostname or IP</li>
 <li>Dashboard auto-discovers:</li>
@@ -977,6 +939,19 @@ packages:
 <p>Recommission alarms, relay modes, bus address, and phase mapping in WebConfig after major firmware upgrades if the module boots with factory settings.</p>
 <hr>
 <h2 id="10-maintenance--troubleshooting">10. Maintenance & Troubleshooting</h2>
+<h3 id="101-status-leds">10.1 Status LEDs</h3>
+<ul>
+<li><strong>PWR</strong> — ON in normal operation</li>
+<li><strong>TX/RX</strong> — blink on Modbus traffic</li>
+<li><strong>User LEDs (1–4)</strong> — follow configured source / mode in <a href="#6-webconfig-reference">§6 WebConfig</a></li>
+</ul>
+<h3 id="102-resets">10.2 Resets</h3>
+<ul>
+<li><strong>Power cycle:</strong> remove 24 V, wait, re-apply</li>
+<li><strong>Buttons 1 + 2</strong> — enter <strong>BOOT</strong> mode for UF2 flashing</li>
+<li><strong>Buttons 3 + 4</strong> — hardware <strong>RESET</strong></li>
+</ul>
+<h3 id="103-common-issues">10.3 Common issues</h3>
 <table>
 <thead><tr><th>Symptom</th><th>Fix or Explanation</th></tr></thead><tbody>
 <tr><td>Relay won’t activate</td><td>Check mode: <strong>Alarm Controlled</strong> follows alarms; <strong>Modbus</strong> only via coils 0/1</td></tr>
@@ -1099,7 +1074,6 @@ packages:
 <li>💬 <a href="https://reddit.com/r/HomeMaster">Reddit Community</a> — Questions, answers, contributions  </li>
 <li>📸 <a href="https://instagram.com/home_master.eu">Instagram</a> — Visual updates and field applications</li>
 </ul>
-    </article>
-  </div>
+  </article></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Clean §5.4 to three phases (Wire / Configure / Integrate); remove duplicate RS-485/USB-C and stray Physical/Cable/Defaults/Steps blocks.
- Renumber §8 to contiguous 8.1–8.6; split §7 Input Registers; add §10.1–10.3; de-duplicate Standards into §12 (altitude/REACH kept in §3.3).
- Drop decorative emoji from §5.1 `####` headings; sync `readme.html`.

## Test plan
- [ ] §5.4 has Wire / Configure / Integrate only (no stray Physical/Defaults/Steps)
- [ ] §8 is 8.1–8.6; §7 has Input Registers subsection; §10 has 10.1–10.3
- [ ] No Standards table duplicated under §3; no decorative emoji in §5.1 headings
- [ ] Docs only; facts/registers/versions unchanged


Made with [Cursor](https://cursor.com)