### PR TITLE
feat(wifi): EN 18031-1 API encryption + provisioning (ESPHome 2026.7.0)

### DIFF
--- a/MicroPLC/Firmware/CHANGELOG.md
+++ b/MicroPLC/Firmware/CHANGELOG.md
@@ -1,8 +1,13 @@
+### v1.1.0 — current
+
+- EN 18031-1 / RED Art. 3(3)(d): require ESPHome ≥ 2026.7.0; enable `api.encryption` without a baked-in key and add `provisioning:` (15 min window).
+- Project version bumped to v1.1.0 (OTA downgrade protection uses this value).
+
 # Changelog — HomeMaster MicroPLC
 
 Firmware release history. ESPHome configuration (`microplc.yaml`) lives in this folder.
 
-### v1.0.0 — current
+### v1.0.0
 
 - Initial public firmware release for MicroPLC-R1 hardware V1.0.
 - ESPHome pre-installed with Improv Wi-Fi provisioning (BLE + USB Serial).

--- a/MicroPLC/Firmware/microplc.yaml
+++ b/MicroPLC/Firmware/microplc.yaml
@@ -4,7 +4,7 @@ substitutions:
   room: ""                              # Optional: assign device to a room in HA
   device_description: "Homemaster MicroPLC"  # Description for documentation
   project_name: "Homemaster.MicroPLC"   # Project identifier
-  project_version: "v1.0.0"             # Firmware version
+  project_version: "v1.1.0"             # Firmware version
   update_interval: 60s                  # Default sensor update interval
   dns_domain: ".local"                  # mDNS domain suffix for network discovery
   timezone: ""                          # Timezone (can be set if device runs in different region)
@@ -18,7 +18,7 @@ esphome:
   comment: "${device_description}"      # Metadata comment
   area: "${room}"                       # Assign device to a room
   name_add_mac_suffix: true             # Appends MAC suffix to avoid duplicate hostnames
-  min_version: 2025.7.0                 # Minimum ESPHome version required
+  min_version: 2026.7.0                 # Minimum ESPHome version required
   project:
     name: "${project_name}"             # Project name
     version: "${project_version}"       # Project version
@@ -37,6 +37,16 @@ mdns:
   disabled: false                       # Enable mDNS for auto-discovery on the network
 
 api:                                    # Enable ESPHome API for Home Assistant integration
+  encryption:
+    # No `key:` here — intentional and required. The key is set during
+    # provisioning. A key baked into a publicly published factory binary
+    # would be identical on every unit, i.e. equivalent to no key at all.
+
+provisioning:
+  timeout: 15min
+  on_timeout:
+    then:
+      - logger.log: "Provisioning window closed. Power-cycle the device to reopen it."
 
 ota:
   - platform: esphome

--- a/MiniPLC/Firmware/CHANGELOG.md
+++ b/MiniPLC/Firmware/CHANGELOG.md
@@ -1,8 +1,14 @@
+### v1.1.0 — current
+
+- EN 18031-1 / RED Art. 3(3)(d): require ESPHome ≥ 2026.7.0; enable `api.encryption` without a baked-in key and add `provisioning:` (15 min window).
+- Removed unauthenticated `web_server:` from the factory image. After adoption, users can re-add it with `auth:` (and `allowed_origins:` on ESPHome 2026.7.0+) via `dashboard_import` (`import_full_config: true`).
+- Project version bumped to 1.1.0 (OTA downgrade protection uses this value).
+
 # Changelog — HomeMaster MiniPLC
 
 Firmware release history. OTA binaries and `manifest.json` live in this folder.
 
-### v1.0.1 — current
+### v1.0.1
 
 - Aligned README structure with the OpenTherm Gateway README.
 - Removed captive-portal fallback AP from documentation — provisioning is now Improv-only (BLE + USB Serial).

--- a/MiniPLC/Firmware/config-eth.yaml
+++ b/MiniPLC/Firmware/config-eth.yaml
@@ -2,11 +2,11 @@ esphome:
   name: homemaster-miniplc
   friendly_name: Homemaster MiniPLC
   comment: Homemaster MiniPLC
-  min_version: 2025.7.0
+  min_version: 2026.7.0
   name_add_mac_suffix: false
   project:
     name: homemaster.miniplc
-    version: 1.0.0
+    version: 1.1.0
 
 esp32:
   board: esp32dev
@@ -18,11 +18,16 @@ logger:
   baud_rate: 115200
 
 api:
+  encryption:
+    # No `key:` here — intentional and required. The key is set during
+    # provisioning. A key baked into a publicly published factory binary
+    # would be identical on every unit, i.e. equivalent to no key at all.
 
-web_server:
-  port: 80
-  version: 3
-  ota: false
+provisioning:
+  timeout: 15min
+  on_timeout:
+    then:
+      - logger.log: "Provisioning window closed. Power-cycle the device to reopen it."
 
 # RS-485 / Modbus RTU bus. The UART is exposed below as `uart_modbus`.
 # Users can attach their own `modbus_controller:` blocks to integrate

--- a/MiniPLC/Firmware/miniplc.yaml
+++ b/MiniPLC/Firmware/miniplc.yaml
@@ -2,11 +2,11 @@ esphome:
   name: homemaster-miniplc
   friendly_name: Homemaster MiniPLC
   comment: Homemaster MiniPLC
-  min_version: 2025.7.0
+  min_version: 2026.7.0
   name_add_mac_suffix: true
   project:
     name: homemaster.miniplc
-    version: "1.0.0"
+    version: "1.1.0"
 
 esp32:
   board: esp32dev
@@ -18,11 +18,16 @@ logger:
   baud_rate: 115200
 
 api:
+  encryption:
+    # No `key:` here — intentional and required. The key is set during
+    # provisioning. A key baked into a publicly published factory binary
+    # would be identical on every unit, i.e. equivalent to no key at all.
 
-web_server:
-  port: 80
-  version: 3
-  ota: false
+provisioning:
+  timeout: 15min
+  on_timeout:
+    then:
+      - logger.log: "Provisioning window closed. Power-cycle the device to reopen it."
 
 # RS-485 / Modbus RTU bus. The UART is exposed below as `uart_modbus`.
 # Users can attach their own `modbus_controller:` blocks to integrate

--- a/OpenthermGateway/Firmware/CHANGELOG.md
+++ b/OpenthermGateway/Firmware/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Firmware release history. OTA binaries and `manifest.json` live in this folder.
 
+### v1.1.0 — current
+
+- EN 18031-1 / RED Art. 3(3)(d): require ESPHome ≥ 2026.7.0; enable `api.encryption` without a baked-in key and add `provisioning:` (15 min window).
+- Project version bumped from 1.0.7 to 1.1.0 (OTA downgrade protection uses this value).
+
 ### v1.0.7 — documentation update
 
 - **Documentation:** trademark attribution added; version sync.
@@ -15,10 +20,10 @@ Firmware release history. OTA binaries and `manifest.json` live in this folder.
 - Updated device documentation wording in index.md per maintainer review.
 - Firmware recompiled with ESPHome 2026.5.3; new OTA binary published.
 
-### v1.0.6 — current (documentation update)
+### v1.0.6 — documentation update
 
 - **Safety:** Added relay output use-restriction warning to comply with the Basic-insulation rating between mains primary (L/N) and relay output (C, NC) tracks on the Relay board, REV1.0. The restriction will be lifted in REV2 of the hardware where Reinforced insulation is achieved by PCB redesign.
 
-### v1.0.6 — current
+### v1.0.6
 
 - Initial public firmware release for OTGW-R1 hardware V1.0.

--- a/OpenthermGateway/Firmware/opentherm.yaml
+++ b/OpenthermGateway/Firmware/opentherm.yaml
@@ -2,9 +2,10 @@ esphome:
   name: homemaster-opentherm
   name_add_mac_suffix: true
   friendly_name: HomeMaster OpenTherm Gateway
+  min_version: 2026.7.0
   project:
     name: homemaster.opentherm_gateway
-    version: "1.0.7"
+    version: "1.1.0"
 
 esp32:
   variant: esp32
@@ -16,6 +17,16 @@ esp32:
 logger:
 
 api:
+  encryption:
+    # No `key:` here — intentional and required. The key is set during
+    # provisioning. A key baked into a publicly published factory binary
+    # would be identical on every unit, i.e. equivalent to no key at all.
+
+provisioning:
+  timeout: 15min
+  on_timeout:
+    then:
+      - logger.log: "Provisioning window closed. Power-cycle the device to reopen it."
 
 wifi:
   ap:


### PR DESCRIPTION
## Summary
- MiniPLC / MicroPLC / OpenTherm: `min_version: 2026.7.0`, project version → 1.1.0
- `api.encryption` without baked-in key + `provisioning:` (15 min window)
- Remove unauthenticated `web_server:` from MiniPLC factory YAMLs (re-add with auth after adoption)
- CHANGELOG entries for all three modules

## Test plan
- [x] `esphome config` on all four YAMLs (ESPHome 2026.7.0)
- [x] `esphome compile` MiniPLC `miniplc.yaml`
- [ ] Bench: Modbus after ESPHome 2026.7.0 (separate risk — defaults changed)


Made with [Cursor](https://cursor.com)