### PR TITLE
release(MicroPLC): 1.1.1 version bump and changelog

### DIFF
--- a/MicroPLC/Firmware/CHANGELOG.md
+++ b/MicroPLC/Firmware/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 Firmware release history. OTA binaries and `manifest.json` live in this folder alongside `microplc.yaml`.
 
-### v1.1.0 — current
+### v1.1.1 — current
+
+- Dropped the `substitutions` block; values inlined as literals — configuration aligned with OpenthermGateway and MiniPLC.
+- Removed `mdns`, `network`, and the default-only keys `wifi.fast_connect`, `wifi.domain`, `esphome.area`, `logger.level`.
+- `friendly_name` and `project.name` normalised to the HomeMaster trademark casing.
+- Network updates: `http_request`, OTA via `http_request`, `update` polling `manifest.json` every **6 h**, plus a check **10 s** after Wi-Fi connect.
+
+### v1.1.0
 
 - EN 18031-1 / RED Art. 3(3)(d): require ESPHome ≥ **2026.7.0**; enable `api.encryption` **without** a baked-in key (per-device key set at adoption) and add `provisioning:` (**15 min** window after power-on; power-cycle to reopen).
 - Vendor-managed network updates via `manifest.json` (`update.http_request`, poll every **6 h**).

--- a/MicroPLC/Firmware/microplc.yaml
+++ b/MicroPLC/Firmware/microplc.yaml
@@ -6,7 +6,7 @@ esphome:
   min_version: 2026.7.0
   project:
     name: homemaster.microplc
-    version: "1.1.0"
+    version: "1.1.1"
 
 esp32:
   board: esp32dev                       # Target board type (generic ESP32 DevKit)


### PR DESCRIPTION
## Summary
- Bump `esphome.project.version` to **1.1.1**
- Changelog: v1.1.1 current (substitutions removed, defaults trimmed, HomeMaster casing, HTTP OTA)

## Note
OTA binary / `manifest.json` not updated — field binary is still 1.1.0.

## Test plan
- [x] Only `project.version` changed in YAML
- [ ] Add 1.1.1 `.ota.bin` + manifest in a follow-up single commit

Made with [Cursor](https://cursor.com)