### PR TITLE
ci: CycloneDX SBOM workflows and SECURITY.md

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -79,6 +79,28 @@ jobs:
             --dump-profile \
             . 2>&1 | tee profile-dump.txt
 
+      - name: Generate SBOM (CycloneDX)
+        working-directory: ${{ matrix.module }}/Firmware/v0.2.0/${{ matrix.sketch }}
+        run: |
+          python3 "${GITHUB_WORKSPACE}/tools/sbom_arduino.py" \
+            --module "${{ matrix.module }}" \
+            --sketch "${{ matrix.sketch }}" \
+            --profile profile-dump.txt \
+            --fw-version 0.2.0 \
+            --out "${{ matrix.module }}.cdx.json"
+
+      - name: Validate SBOM
+        working-directory: ${{ matrix.module }}/Firmware/v0.2.0/${{ matrix.sketch }}
+        run: |
+          # Fail the build if the SBOM is not valid CycloneDX or has no components.
+          python3 - "${{ matrix.module }}.cdx.json" <<'PY'
+          import json, sys
+          b = json.load(open(sys.argv[1]))
+          assert b.get("bomFormat") == "CycloneDX", "not CycloneDX"
+          assert b.get("components"), "SBOM has no components"
+          print(f"SBOM OK: {len(b['components'])} components")
+          PY
+
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4
         with:
@@ -86,4 +108,5 @@ jobs:
           path: |
             ${{ matrix.module }}/Firmware/v0.2.0/${{ matrix.sketch }}/build/**/*.uf2
             ${{ matrix.module }}/Firmware/v0.2.0/${{ matrix.sketch }}/profile-dump.txt
+            ${{ matrix.module }}/Firmware/v0.2.0/${{ matrix.sketch }}/${{ matrix.module }}.cdx.json
           if-no-files-found: error

--- a/.github/workflows/sbom-esphome.yml
+++ b/.github/workflows/sbom-esphome.yml
@@ -1,0 +1,83 @@
+# Generate CycloneDX SBOMs for the three ESP32 / ESPHome radio modules.
+#
+# These are not built by build-firmware.yml (that one is the RP2350 Arduino line).
+# The ESPHome modules are built in Device Builder, so this workflow does not
+# compile them — it derives the SBOM from the pinned versions and the YAML.
+#
+# Place at: .github/workflows/sbom-esphome.yml
+# The generator is at: tools/sbom_esphome.py
+#
+# IMPORTANT: keep ESPHOME_VERSION in step with the version you actually build in
+# Device Builder. When you bump the toolchain, bump it here — the SBOM must
+# describe what shipped.
+
+name: SBOM (ESPHome modules)
+
+on:
+  push:
+    paths:
+      - 'MiniPLC/Firmware/**.yaml'
+      - 'MicroPLC/Firmware/**.yaml'
+      - 'OpenthermGateway/Firmware/**.yaml'
+      - 'tools/sbom_esphome.py'
+      - '.github/workflows/sbom-esphome.yml'
+  workflow_dispatch:
+
+env:
+  ESPHOME_VERSION: '2026.7.0'
+  FRAMEWORK_VERSION: '5.3.1'   # ESP-IDF version ESPHome 2026.7.x resolves; verify against build logs
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: MiniPLC
+            yaml: MiniPLC/Firmware/miniplc.yaml
+            fw: '1.2.0'
+          - module: MicroPLC
+            yaml: MicroPLC/Firmware/microplc.yaml
+            fw: '1.2.0'
+          - module: OpenthermGateway
+            yaml: OpenthermGateway/Firmware/opentherm.yaml
+            fw: '1.2.0'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pyyaml
+        run: pip install pyyaml
+
+      - name: Generate SBOM
+        run: |
+          python3 tools/sbom_esphome.py \
+            --module "${{ matrix.module }}" \
+            --yaml "${{ matrix.yaml }}" \
+            --esphome-version "${ESPHOME_VERSION}" \
+            --framework-version "${FRAMEWORK_VERSION}" \
+            --fw-version "${{ matrix.fw }}" \
+            --out "${{ matrix.module }}.cdx.json"
+
+      - name: Validate SBOM
+        run: |
+          python3 - "${{ matrix.module }}.cdx.json" <<'PY'
+          import json, sys
+          b = json.load(open(sys.argv[1]))
+          assert b.get("bomFormat") == "CycloneDX", "not CycloneDX"
+          assert b.get("components"), "SBOM has no components"
+          print(f"SBOM OK: {len(b['components'])} components")
+          PY
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ matrix.module }}
+          path: ${{ matrix.module }}.cdx.json
+          if-no-files-found: error

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,92 @@
+# Security Policy
+
+ISYSTEMS AUTOMATION S.R.L. (HomeMaster®) takes the security of its products
+seriously. This document explains how to report a vulnerability and what to
+expect in return.
+
+## Reporting a vulnerability
+
+**Email:** support@home-master.eu
+**PGP key:** https://www.home-master.eu/.well-known/pgp-key.asc
+**Or:** GitHub private vulnerability reporting on this repository
+
+Please include, where you can:
+
+- affected product and hardware version (e.g. MiniPLC V1.0)
+- firmware version — shown in the ESPHome logs at boot and in Home Assistant
+- what the issue is and what it allows
+- how to reproduce it
+- whether, to your knowledge, it is being exploited
+
+Please do not open a public issue for a security matter.
+
+## What to expect
+
+| Stage | Target |
+|---|---|
+| We acknowledge your report | 3 working days |
+| We give an initial assessment and severity | 10 working days |
+| We keep you updated while we work | every 20 working days |
+| We ship a fix or a documented mitigation | per severity, below |
+
+| Severity | Target |
+|---|---|
+| Critical — remote code execution, or unauthenticated control of a relay switching mains | 30 days |
+| High — authentication bypass, credential exposure | 60 days |
+| Medium | 90 days |
+| Low | next release |
+
+We work to coordinated disclosure and will credit you in the advisory unless you
+ask us not to.
+
+## Products in scope
+
+All HomeMaster modules and their firmware:
+
+AIO-422-R1 · ALM-173-R1 · DIM-420-R1 · DIO-430-R1 · ENM-223-R1 · MicroPLC ·
+MiniPLC · OpenTherm Gateway · RGB-621-R1 · STR-3221-R1 · WLD-521-R1
+
+Also the WebConfig pages at config.home-master.eu and the firmware update
+manifests served from this repository.
+
+Out of scope: Home Assistant, ESPHome and other third-party software — report
+those upstream. We forward anything that reaches us by mistake.
+
+## Support period
+
+Security updates are provided for each module for **10 years** from the date the
+last unit of that hardware version was placed on the market. This reflects the
+service life of DIN-rail equipment in a fixed installation.
+
+## Advisories
+
+Published at
+https://github.com/isystemsautomation/HOMEMASTER/security/advisories
+and mirrored at https://www.home-master.eu/security
+
+## Regulatory reporting
+
+For products made available on the EU market, actively exploited vulnerabilities
+and severe security incidents are reported to ENISA and to the Romanian national
+CSIRT (DNSC) through the Single Reporting Platform, under Article 14 of Regulation
+(EU) 2024/2847 (Cyber Resilience Act), from 11 September 2026.
+
+## Deploying HomeMaster modules securely
+
+These modules are meant to be installed in a fixed electrical installation by a
+qualified person. To run them safely:
+
+- put them on a network segment separate from general and guest devices — a
+  dedicated VLAN, for instance
+- do not expose a module directly to the internet; do not forward ports to one
+- complete the ESPHome adoption ("Take control") after Wi-Fi provisioning — this
+  sets the per-device API encryption key and OTA password
+- do the initial Wi-Fi provisioning somewhere controlled: the BLE window is open
+  until the device first joins a network
+- keep firmware current; updates are offered automatically in Home Assistant
+
+Per-module detail is in each User Manual.
+
+---
+
+*Last reviewed: 2026-07-25 · Contact: support@home-master.eu*

--- a/tools/sbom_arduino.py
+++ b/tools/sbom_arduino.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Generate a CycloneDX SBOM for a HomeMaster RP2350 module built with arduino-cli.
+
+Input is the `profile-dump.txt` that `arduino-cli compile --dump-profile` writes:
+it lists the exact core and library versions the build actually resolved, which
+is what a CRA SBOM must reflect — the versions that shipped, not the ones a
+manifest hoped for.
+
+Usage:
+    sbom_arduino.py --module ALM-173-R1 --sketch default_alm_173_r1 \
+                    --profile path/to/profile-dump.txt \
+                    --out path/to/ALM-173-R1.cdx.json
+
+The profile dump looks like:
+
+    profiles:
+      default:
+        fqbn: rp2040:rp2040:generic_rp2350:...
+        platforms:
+          - platform: rp2040:rp2040 (5.6.0)
+            platform_index_url: https://...
+        libraries:
+          - ADS1X15 (0.6.2)
+          - Adafruit MAX31865 library (1.6.2)
+
+We parse the `platforms:` and `libraries:` blocks. Anything we cannot parse is
+reported, never silently dropped — a missing component in an SBOM is worse than
+a noisy one.
+"""
+
+import argparse, json, re, sys, hashlib, datetime, uuid
+
+
+def parse_profile(text):
+    """Return (platforms, libraries) as lists of (name, version)."""
+    platforms, libraries = [], []
+    section = None
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        stripped = line.strip()
+        if re.match(r'^platforms:\s*$', stripped):
+            section = 'platforms'; continue
+        if re.match(r'^libraries:\s*$', stripped):
+            section = 'libraries'; continue
+        # a new top-level-ish key ends the current section
+        if stripped and not stripped.startswith('-') and stripped.endswith(':') \
+           and section and not line.startswith('   '):
+            section = None
+
+        m = re.match(r'-\s*(?:platform:\s*)?(.+?)\s*\(([^)]+)\)\s*$', stripped)
+        if m and section == 'platforms':
+            platforms.append((m.group(1).strip(), m.group(2).strip()))
+        elif m and section == 'libraries':
+            libraries.append((m.group(1).strip(), m.group(2).strip()))
+    return platforms, libraries
+
+
+def purl(kind, name, version):
+    # arduino has no official purl type; use a stable, documented namespace
+    safe = re.sub(r'\s+', '.', name.strip())
+    return f'pkg:arduino/{kind}/{safe}@{version}'
+
+
+def component(kind, name, version):
+    return {
+        "type": "library",
+        "name": name,
+        "version": version,
+        "purl": purl(kind, name, version),
+        "properties": [{"name": "homemaster:origin", "value": kind}],
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--module', required=True)
+    ap.add_argument('--sketch', required=True)
+    ap.add_argument('--profile', required=True)
+    ap.add_argument('--fw-version', default='0.2.0')
+    ap.add_argument('--out', required=True)
+    a = ap.parse_args()
+
+    text = open(a.profile, encoding='utf-8', errors='replace').read()
+    platforms, libraries = parse_profile(text)
+
+    if not platforms and not libraries:
+        print(f'ERROR: no components parsed from {a.profile}. '
+              f'Is this an arduino-cli --dump-profile output?', file=sys.stderr)
+        sys.exit(1)
+
+    comps = [component('core', n, v) for n, v in platforms] + \
+            [component('library', n, v) for n, v in libraries]
+
+    serial = 'urn:uuid:' + str(uuid.uuid4())
+    now = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    bom = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "serialNumber": serial,
+        "version": 1,
+        "metadata": {
+            "timestamp": now,
+            "tools": [{"vendor": "HomeMaster", "name": "sbom_arduino.py", "version": "1.0"}],
+            "component": {
+                "type": "firmware",
+                "name": f"HomeMaster {a.module}",
+                "version": a.fw_version,
+                "description": f"Firmware for HomeMaster {a.module} ({a.sketch}), RP2350",
+                "properties": [
+                    {"name": "homemaster:module", "value": a.module},
+                    {"name": "homemaster:sketch", "value": a.sketch},
+                    {"name": "homemaster:mcu", "value": "RP2350"},
+                ],
+            },
+        },
+        "components": comps,
+    }
+
+    with open(a.out, 'w', encoding='utf-8') as f:
+        json.dump(bom, f, indent=2, ensure_ascii=False)
+
+    print(f'{a.module}: {len(platforms)} core, {len(libraries)} libraries -> {a.out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/sbom_esphome.py
+++ b/tools/sbom_esphome.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Generate a CycloneDX SBOM for a HomeMaster ESP32 module built with ESPHome.
+
+Unlike the Arduino line, these are configured in YAML and built by ESPHome on top
+of ESP-IDF. The authoritative version list is what `esphome compile` resolves:
+the ESPHome release, the ESP-IDF / framework version, and every external
+component and library the YAML pulls in.
+
+Two input modes:
+
+1. --manifest <compile_commands or idf build manifest>  (preferred, exact)
+   If the build directory has been produced, pass the ESPHome build manifest
+   (.esphome/build/<name>/... ) so versions come from what was actually compiled.
+
+2. --yaml <config.yaml> --esphome-version <x> --framework-version <y>  (fallback)
+   Parse the YAML for `esphome.libraries`, `external_components`, and known
+   platform components, and take the ESPHome/framework versions from the args
+   (which the CI knows because it pins them).
+
+Mode 2 is what the CI uses, because it runs before a full IDF build and the
+pinned versions are known up front. Anything not parseable is reported.
+
+Usage (CI, mode 2):
+    sbom_esphome.py --module MiniPLC --yaml MiniPLC/Firmware/miniplc.yaml \
+        --esphome-version 2026.7.0 --framework-version 5.3.1 \
+        --fw-version 1.2.0 --out MiniPLC.cdx.json
+"""
+
+import argparse, json, re, sys, uuid, datetime
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
+def load_yaml(path):
+    if yaml is None:
+        print('ERROR: pyyaml not available; install pyyaml', file=sys.stderr)
+        sys.exit(1)
+    with open(path, encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+
+def purl_pypi(name, version):
+    return f'pkg:pypi/{name}@{version}'
+
+
+def comp(ctype, name, version, origin, purl=None):
+    c = {"type": ctype, "name": name, "version": version,
+         "properties": [{"name": "homemaster:origin", "value": origin}]}
+    if version:
+        if purl:
+            c["purl"] = purl
+    else:
+        c["version"] = "unspecified"
+    return c
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--module', required=True)
+    ap.add_argument('--yaml', required=True)
+    ap.add_argument('--esphome-version', required=True)
+    ap.add_argument('--framework-version', default='')
+    ap.add_argument('--fw-version', required=True)
+    ap.add_argument('--out', required=True)
+    a = ap.parse_args()
+
+    cfg = load_yaml(a.yaml) or {}
+    comps = []
+    unresolved = []
+
+    # ESPHome itself
+    comps.append(comp('application', 'esphome', a.esphome_version, 'esphome',
+                      purl=purl_pypi('esphome', a.esphome_version)))
+
+    # ESP-IDF / framework
+    if a.framework_version:
+        comps.append(comp('framework', 'esp-idf', a.framework_version, 'framework'))
+    else:
+        # try to read it from the yaml esp32.framework block
+        fw = (cfg.get('esp32') or {}).get('framework') or {}
+        v = fw.get('version')
+        if v:
+            comps.append(comp('framework', 'esp-idf', str(v), 'framework'))
+        else:
+            unresolved.append('esp-idf framework version (not in args or yaml)')
+
+    # esphome.libraries — arbitrary Arduino/PlatformIO libs the config declares
+    esph = cfg.get('esphome') or {}
+    for lib in esph.get('libraries', []) or []:
+        s = str(lib)
+        m = re.match(r'(.+?)[@=]([\w.\-+]+)\s*$', s)
+        if m:
+            comps.append(comp('library', m.group(1).strip(), m.group(2), 'esphome.libraries'))
+        else:
+            comps.append(comp('library', s.strip(), '', 'esphome.libraries'))
+            unresolved.append(f'library without pinned version: {s}')
+
+    # external_components — from git/local sources
+    for ec in cfg.get('external_components', []) or []:
+        src = ec.get('source', {})
+        if isinstance(src, str):
+            name, ver = src, ''
+        else:
+            name = src.get('url') or src.get('path') or 'external_component'
+            ver = src.get('ref', '')
+        comps.append(comp('library', str(name), str(ver), 'external_components'))
+        if not ver:
+            unresolved.append(f'external_component without ref: {name}')
+
+    # note the presence of core platform components that carry security weight
+    for key in ('api', 'ota', 'provisioning', 'web_server', 'wifi', 'captive_portal'):
+        if key in cfg:
+            comps.append(comp('library', f'esphome:{key}', a.esphome_version,
+                              'esphome.component'))
+
+    serial = 'urn:uuid:' + str(uuid.uuid4())
+    now = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    bom = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "serialNumber": serial,
+        "version": 1,
+        "metadata": {
+            "timestamp": now,
+            "tools": [{"vendor": "HomeMaster", "name": "sbom_esphome.py", "version": "1.0"}],
+            "component": {
+                "type": "firmware",
+                "name": f"HomeMaster {a.module}",
+                "version": a.fw_version,
+                "description": f"Firmware for HomeMaster {a.module}, ESP32 / ESPHome",
+                "properties": [
+                    {"name": "homemaster:module", "value": a.module},
+                    {"name": "homemaster:mcu", "value": "ESP32"},
+                    {"name": "homemaster:framework", "value": "esphome"},
+                ],
+            },
+        },
+        "components": comps,
+    }
+
+    with open(a.out, 'w', encoding='utf-8') as f:
+        json.dump(bom, f, indent=2, ensure_ascii=False)
+
+    print(f'{a.module}: {len(comps)} components -> {a.out}')
+    if unresolved:
+        print(f'{a.module}: {len(unresolved)} unresolved:', file=sys.stderr)
+        for u in unresolved:
+            print(f'  - {u}', file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Insert Generate/Validate SBOM after Compile in `build-firmware.yml`; upload `*.cdx.json`
- Add `tools/sbom_arduino.py`, `tools/sbom_esphome.py`, `.github/workflows/sbom-esphome.yml`
- Add root `SECURITY.md`

## Test plan
- [ ] `build-firmware.yml` runs Generate + Validate SBOM and uploads `.cdx.json`
- [ ] `sbom-esphome.yml` workflow_dispatch produces three module SBOMs

Made with [Cursor](https://cursor.com)